### PR TITLE
Remove jobs relationship

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -191,39 +191,20 @@ components:
 
     EmployeeRelationships:
       type: object
-      required: [jobs]
+      required: [position, location]
       properties:
-        jobs:
+        position:
           type: object
           required: [data]
           properties:
             data:
-              type: array
-              minItems: 1
-              items:
-                type: object
-                required: [type, relationships]
-                properties:
-                  type:
-                    type: string
-                    enum: [jobs]
-                    example: jobs
-                  relationships:
-                    type: object
-                    required: [position, location]
-                    properties:
-                      position:
-                        type: object
-                        required: [data]
-                        properties:
-                          data:
-                            $ref: '#/components/schemas/PositionsRelationship'
-                      location:
-                        type: object
-                        required: [data]
-                        properties:
-                          data:
-                            $ref: '#/components/schemas/LocationsRelationship'
+              $ref: '#/components/schemas/PositionsRelationship'
+        location:
+          type: object
+          required: [data]
+          properties:
+            data:
+              $ref: '#/components/schemas/LocationsRelationship'
 
     Address:
       type: object


### PR DESCRIPTION
The jobs relationship used a nested relationship pattern which doesn't fit JSON:API specifications. This update is to bring our API back into spec.