### PR TITLE
[API] Add information about what filters can be applied to the GET /employees

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -33,6 +33,16 @@ paths:
       tags:
         - Employees
       summary: Get a list of employees
+      parameters:
+        - name: filters
+          in: query
+          description: Filters applied to the list of employees
+          required: false
+          schema:
+            type: object
+            properties:
+              external_identifier:
+                type: string
       responses:
         '200':
           description: A list of employees in JSON:API format


### PR DESCRIPTION
The original API docs didn't detail the filter object and the ability to filter by `external_id`, which is currently the only acceptable filter, per https://github.com/KevalaCare/kevala-platform/blob/main/api/controllers/v1/employee_controller.ex#L10