### PR TITLE
Use the EmployeeResponse in the patch body

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -114,7 +114,12 @@ paths:
         content:
           application/vnd.api+json:
             schema:
-              $ref: '#/components/schemas/EmployeeResource'
+              type: object
+              properties:
+                data:
+                  $ref: '#/components/schemas/EmployeeResponse'
+              required:
+                - data
       responses:
         '200':
           description: Updated employee in JSON:API format
@@ -281,9 +286,6 @@ components:
         data:
           type: object
           properties:
-            id:
-              type: string
-              example: '1'
             type:
               type: string
               enum: [employees]
@@ -293,7 +295,6 @@ components:
             relationships:
               $ref: '#/components/schemas/EmployeeRelationships'
           required:
-            - id
             - type
             - attributes
             - relationships


### PR DESCRIPTION
My previous update in #7 required the ID to be passed in the `POST`, which was wrong. This PR updates the docs to drop the id from the `EmployeeResource` (used in the `POST`) and to require instead the `EmployeeResponse` in the patch body.